### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Build Docker Image
       run: docker build . --file Dockerfile --tag gitpod-android:$(date +%s)
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         # The name of the image you would like to push
         name: pranav8350/gitpod-android


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore